### PR TITLE
Improve select styling and category badges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
 body {
   background: #f9f9f9;
-  font-family: 'Inter', Arial, sans-serif;
+  font-family: 'Poppins', Arial, sans-serif;
   color: #222;
   margin: 0;
 }
@@ -42,6 +44,7 @@ select, .bubble-group {
   flex-wrap: wrap;
   gap: 0.5em;
   margin-bottom: 1em;
+  justify-content: center;
 }
 
 .bubble {
@@ -54,7 +57,8 @@ select, .bubble-group {
   border: 1px solid #ccc;
   transition: background .2s, border-color .2s;
 }
-.bubble.selected {
+.bubble.selected,
+.category-badge.selected {
   background: #143F90;
   color: #fff;
   border-color: #143F90;
@@ -79,5 +83,42 @@ select, .bubble-group {
 
 body.dark {
   background: #000;
+}
+
+/* Podloga za dropdowne */
+.select-modern {
+  background: #fdf2f8;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  padding: 0.8em 1em;
+  font-size: 1rem;
+  color: #333;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Hover i focus efekti */
+.select-modern:hover,
+.select-modern:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Kategorije "Presentations" i "Activations" kao mjehurići */
+.category-badge {
+  display: inline-block;
+  margin: 0.25em;
+  padding: 0.6em 1.2em;
+  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  border-radius: 20px;
+  color: #fff;
+  font-weight: 600;
+  transition: background 0.3s ease, transform 0.1s ease;
+  cursor: pointer;
+}
+
+/* Interakcija na klik */
+.category-badge:active {
+  transform: scale(0.95);
+  background: linear-gradient(135deg, #fad0c4, #ff9a9e);
 }
 

--- a/decision.html
+++ b/decision.html
@@ -11,14 +11,14 @@
     <h1>Decision Factors Reporting</h1>
     <form id="decisionForm">
       <label>Location:</label>
-      <select id="location">
+      <select id="location" class="select-modern">
         <option value="Zagreb">Zagreb</option>
         <option value="Split">Split</option>
         <option value="Osijek">Osijek</option>
       </select>
 
       <label>Key Purchase Driver:</label>
-      <select id="driver">
+      <select id="driver" class="select-modern">
         <option value="Camera">Camera</option>
         <option value="Processor">Processor</option>
         <option value="Battery">Battery</option>
@@ -27,14 +27,14 @@
       </select>
 
       <label>Top Feature Category:</label>
-      <select id="featureCategory">
+      <select id="featureCategory" class="select-modern">
         <option value="True AI companion">True AI companion</option>
         <option value="Performance">Performance</option>
         <option value="Camera Experience">Camera Experience</option>
       </select>
 
       <label>Sub-feature:</label>
-      <select id="subfeature">
+      <select id="subfeature" class="select-modern">
         <option value="Human-like AI Agent">Human-like AI Agent</option>
         <option value="Integrated AI Platform">Integrated AI Platform</option>
         <option value="Personalized AI">Personalized AI</option>

--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
     <h1>Consumer Insights Reporting</h1>
     <form id="reportForm">
       <label>Location:</label>
-      <select id="location">
+      <select id="location" class="select-modern">
         <option value="Zagreb">Zagreb</option>
         <option value="Split">Split</option>
         <option value="Osijek">Osijek</option>
       </select>
 
       <label>OS Type (optional):</label>
-      <select id="osType">
+      <select id="osType" class="select-modern">
         <option value=""></option>
         <option value="Android Samsung">Android Samsung</option>
         <option value="Android other">Android other</option>
@@ -27,18 +27,18 @@
 
       <label>Presentations:</label>
       <div id="presentations" class="bubble-group">
-        <div class="bubble option" data-value="Galaxy phones">Galaxy phones</div>
-        <div class="bubble option" data-value="Galaxy wearables">Galaxy wearables</div>
-        <div class="bubble option" data-value="Galaxy tablet">Galaxy tablet</div>
-        <div class="bubble option" data-value="AC">AC</div>
+        <div class="category-badge option" data-value="Galaxy phones">Galaxy phones</div>
+        <div class="category-badge option" data-value="Galaxy wearables">Galaxy wearables</div>
+        <div class="category-badge option" data-value="Galaxy tablet">Galaxy tablet</div>
+        <div class="category-badge option" data-value="AC">AC</div>
       </div>
 
       <label>Activations:</label>
       <div id="activations" class="bubble-group">
-        <div class="bubble option" data-value="Sound illusion">Sound illusion</div>
-        <div class="bubble option" data-value="Optical Illusion Art">Optical Illusion Art</div>
-        <div class="bubble option" data-value="Interpreting Facial Expressions">Interpreting Facial Expressions</div>
-        <div class="bubble option" data-value="Hidden in plain sight">Hidden in plain sight</div>
+        <div class="category-badge option" data-value="Sound illusion">Sound illusion</div>
+        <div class="category-badge option" data-value="Optical Illusion Art">Optical Illusion Art</div>
+        <div class="category-badge option" data-value="Interpreting Facial Expressions">Interpreting Facial Expressions</div>
+        <div class="category-badge option" data-value="Hidden in plain sight">Hidden in plain sight</div>
       </div>
 
       <button type="submit" class="primary-btn">Pošalji</button>


### PR DESCRIPTION
## Summary
- use Poppins font across the site
- center presentation and activation badges
- style dropdowns with `select-modern`
- style categories with `category-badge`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b80cd9334832f936170f7494dd58e