### PR TITLE
Enhance styling with modern dropdowns and badges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 body {
   background: #f9f9f9;
-  font-family: 'Inter', Arial, sans-serif;
+  font-family: 'Poppins', 'Inter', Arial, sans-serif;
   color: #222;
   margin: 0;
 }
@@ -81,3 +81,47 @@ body.dark {
   background: #000;
 }
 
+
+/* Modern select dropdown */
+.select-modern {
+  background: #fdf2f8;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  padding: 0.8em 1em;
+  font-size: 1rem;
+  color: #333;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.select-modern:hover,
+.select-modern:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Category badges */
+.category-badge {
+  display: inline-block;
+  margin: 0.25em auto;
+  padding: 0.6em 1.2em;
+  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  border-radius: 20px;
+  color: #fff;
+  font-weight: 600;
+  transition: background 0.3s ease, transform 0.1s ease;
+  cursor: pointer;
+  text-align: center;
+}
+
+.category-badge:active {
+  transform: scale(0.95);
+  background: linear-gradient(135deg, #fad0c4, #ff9a9e);
+}
+
+.bubble-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  margin-bottom: 1em;
+  justify-content: center;
+}

--- a/decision.html
+++ b/decision.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Decision Factors Reporting</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -11,14 +14,14 @@
     <h1>Decision Factors Reporting</h1>
     <form id="decisionForm">
       <label>Location:</label>
-      <select id="location">
+      <select id="location" class="select-modern">
         <option value="Zagreb">Zagreb</option>
         <option value="Split">Split</option>
         <option value="Osijek">Osijek</option>
       </select>
 
       <label>Key Purchase Driver:</label>
-      <select id="driver">
+      <select id="driver" class="select-modern">
         <option value="Camera">Camera</option>
         <option value="Processor">Processor</option>
         <option value="Battery">Battery</option>
@@ -27,14 +30,14 @@
       </select>
 
       <label>Top Feature Category:</label>
-      <select id="featureCategory">
+      <select id="featureCategory" class="select-modern">
         <option value="True AI companion">True AI companion</option>
         <option value="Performance">Performance</option>
         <option value="Camera Experience">Camera Experience</option>
       </select>
 
       <label>Sub-feature:</label>
-      <select id="subfeature">
+      <select id="subfeature" class="select-modern">
         <option value="Human-like AI Agent">Human-like AI Agent</option>
         <option value="Integrated AI Platform">Integrated AI Platform</option>
         <option value="Personalized AI">Personalized AI</option>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Consumer Insights Reporting</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark">
@@ -11,21 +14,21 @@
     <h1>Consumer Insights Reporting</h1>
     <form id="reportForm">
       <label>Location:</label>
-      <select id="location">
+      <select id="location" class="select-modern">
         <option value="Zagreb">Zagreb</option>
         <option value="Split">Split</option>
         <option value="Osijek">Osijek</option>
       </select>
 
       <label>OS Type (optional):</label>
-      <select id="osType">
+      <select id="osType" class="select-modern">
         <option value=""></option>
         <option value="Android Samsung">Android Samsung</option>
         <option value="Android other">Android other</option>
         <option value="iOS">iOS</option>
       </select>
 
-      <label>Presentations:</label>
+      <div class="category-badge">Presentations</div>
       <div id="presentations" class="bubble-group">
         <div class="bubble option" data-value="Galaxy phones">Galaxy phones</div>
         <div class="bubble option" data-value="Galaxy wearables">Galaxy wearables</div>
@@ -33,7 +36,7 @@
         <div class="bubble option" data-value="AC">AC</div>
       </div>
 
-      <label>Activations:</label>
+      <div class="category-badge">Activations</div>
       <div id="activations" class="bubble-group">
         <div class="bubble option" data-value="Sound illusion">Sound illusion</div>
         <div class="bubble option" data-value="Optical Illusion Art">Optical Illusion Art</div>


### PR DESCRIPTION
## Summary
- add Poppins font and include Google font links
- style dropdowns with new `.select-modern` class
- add gradient `.category-badge` elements for Presentations and Activations
- center bubble groups and badges
- update all pages to use the new styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b80cd9334832f936170f7494dd58e