### PR TITLE
Redirect after submit and style tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,9 +69,9 @@ select, .bubble-group {
 .primary-btn {
   width: 100%;
   padding: 0.7em 0;
-  border-radius: 10px;
+  border-radius: 20px;
   border: none;
-  background: #143F90;
+  background: #2fb7e5;
   color: #fff;
   font-weight: bold;
   font-size: 1.15em;
@@ -80,7 +80,7 @@ select, .bubble-group {
   transition: background .2s;
 }
 .primary-btn:hover {
-  background: #244ea8;
+  background: #24a6cf;
 }
 
 body.dark {

--- a/decision.html
+++ b/decision.html
@@ -82,8 +82,8 @@
       });
 
       if (response.ok) {
-        alert("Uspješno poslano!");
         document.getElementById('decisionForm').reset();
+        window.location.href = 'index.html';
       } else {
         const error = await response.json();
         alert("Greška prilikom slanja: " + JSON.stringify(error));

--- a/index.html
+++ b/index.html
@@ -65,6 +65,11 @@
       const presentations = Array.from(document.querySelectorAll('#presentations .selected')).map(div => div.dataset.value);
       const activations = Array.from(document.querySelectorAll('#activations .selected')).map(div => div.dataset.value);
 
+      if (presentations.length === 0 && activations.length === 0) {
+        alert('Odaberite barem jednu kategoriju.');
+        return;
+      }
+
       const record = {
         fields: {
           "Date": new Date().toISOString().split('T')[0],
@@ -85,9 +90,9 @@
       });
 
       if (response.ok) {
-        alert("Uspješno poslano!");
         document.getElementById('reportForm').reset();
         document.querySelectorAll('.option').forEach(el => el.classList.remove('selected'));
+        window.location.href = 'decision.html';
       } else {
         const error = await response.json();
         alert("Greška prilikom slanja: " + JSON.stringify(error));


### PR DESCRIPTION
## Summary
- prevent sending empty category selections
- redirect to `decision.html` after the first form
- redirect back to the index page after sending decisions
- style the **Pošalji** button in light blue

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687b98e4e850832fbac805efcd5d1645